### PR TITLE
docs: add updated `CALCULATION_INTERVAL_SECONDS`

### DIFF
--- a/ELIPs/ELIP-001.md
+++ b/ELIPs/ELIP-001.md
@@ -448,6 +448,10 @@ function processClaims(RewardsMerkleClaim[] calldata claims, address recipient) 
 1. Earnings are cumulative, so earners don't have to claim against all distribution roots they have earnings for. They can simply claim against the latest root and the contract will calculate the difference between their `cumulativeEarnings` and `cumulativeClaimed`. This difference is then transferred to the `recipient` address.  
 2. Each claim can specify which of the earner's earned tokens they want to claim (i.e not all tokens have to be claimed in a single claim)
 
+#### Updated Calculation Interval Seconds
+
+`CALCULATION_INTERVAL_SECONDS` will be updated from 1 week to 1 day to reflect the daily rewards calculation happening in the sidecar. This will enable AVSs to submit rewards with `startTimestamp` and `duration` that are multiples of 1 day instead of 1 week.
+
 ### EigenLayer Middleware
 
 The EigenLayer Middleware SHALL have a mandatory release as part of this ELIP to support performance-based rewards. AVSs MUST upgrade their respective `AVSServiceManager` contracts to inherit the new `ServiceManagerBase` implementation in order to be able to submit performance-based rewards.


### PR DESCRIPTION
The `CALCULATION_INTERVAL_SECONDS` in the `RewardsCoordinator` contract will be updated from 1 week to 1 day to more truly reflect the daily rewards calculation happening in the sidecar.