### PR TITLE
chore: Fix Open PR Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ EigenLayer Improvement Proposals (ELIPs) are the primary mechanisms for proposin
 * Publicly communicate new features, designs, and create space for community input
 * Propose new upgrades for approval & execution
 
-To submit an ELIP, open a [pull request](https://github.com/abbey-titcomb/test-eigenlayer-core-dev/pulls). Ongoing and accepted proposals can be found in /elips. 
+To submit an ELIP, open a [pull request](https://github.com/eigenfoundation/ELIPs/pulls). Ongoing and accepted proposals can be found in /elips. 
 
 ## ELIP Process
 In the early stages, ideas for ELIPs and early drafts should be discussed on [forum.eigenlayer.xyz](https://forum.eigenlayer.xyz/). The following actions require an ELIP:


### PR DESCRIPTION
## Summary
This PR updates the link for submitting ELIP pull requests to point to the correct repository. The previous link directed to an incorrect test repository.

### Changes
- Updated the pull request link in the README:
  - **Old:** [abbey-titcomb/test-eigenlayer-core-dev/pulls](https://github.com/abbey-titcomb/test-eigenlayer-core-dev/pulls)  
  - **New:** [eigenfoundation/ELIPs/pulls](https://github.com/eigenfoundation/ELIPs/pulls)
