### PR TITLE
Fixing Slashable Stake example detail

### DIFF
--- a/ELIPs/ELIP-002.md
+++ b/ELIPs/ELIP-002.md
@@ -252,7 +252,7 @@ In figure 3 below, Operator 1 has a delegation of 100 staked ETH for the ETH Str
 ![Operator Allocations to Operator Sets](../assets/elip-002/figure-3.png)  
 ***Figure 3: Operator Allocations to Operator Sets***
 
-The 85 allocated ETH is slashable exclusively by the AVS originating each Operator Set. In this case, AVS 2, 3, and 4 can slash their associated Operator Sets 2, 3, and 4, respectively. 
+The 85 allocated ETH is slashable exclusively by the AVS originating each Operator Set. In this case, AVS 2, 3, and 4 can slash their associated Operator Sets 3, 4, 5, and 6, respectively. 
 
 Let’s consider another example with three Operators. Figure 4 illustrates two Operator Sets instantiated by AVS 1. AVS 1 has created two Operator Sets for different tasks. For example, this AVS may use Operator Set 1 for assigning generation of ZK proofs to Operators, an expensive computation, and Operator Set 2 for verification of those proofs, a cheaper computation. 
 

--- a/ELIPs/ELIP-002.md
+++ b/ELIPs/ELIP-002.md
@@ -252,7 +252,7 @@ In figure 3 below, Operator 1 has a delegation of 100 staked ETH for the ETH Str
 ![Operator Allocations to Operator Sets](../assets/elip-002/figure-3.png)  
 ***Figure 3: Operator Allocations to Operator Sets***
 
-The 85 allocated ETH is slashable exclusively by the AVS originating each Operator Set. In this case, AVS 2, 3, and 4 can slash their associated Operator Sets 3, 4, 5, and 6, respectively. 
+The 85 allocated ETH is slashable exclusively by the AVS originating each Operator Set. In this case, AVS 2, 3, and 4 can slash their associated Operator Sets 3, 4, and 5, respectively. 
 
 Let’s consider another example with three Operators. Figure 4 illustrates two Operator Sets instantiated by AVS 1. AVS 1 has created two Operator Sets for different tasks. For example, this AVS may use Operator Set 1 for assigning generation of ZK proofs to Operators, an expensive computation, and Operator Set 2 for verification of those proofs, a cheaper computation. 
 


### PR DESCRIPTION
Please note the potential numbering mistake vs the diagram Op Set numbers:

<img width="903" alt="image" src="https://github.com/user-attachments/assets/5e0cacf2-cfa7-42f1-8b39-b1824cb01035" />
<img width="1116" alt="image" src="https://github.com/user-attachments/assets/688ef786-1e2b-4507-812d-14aa84e16580" />
